### PR TITLE
fix: change openJDK distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM eclipse-temurin:11
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 EXPOSE 8080


### PR DESCRIPTION
OpenJDK docker image is deprecated: https://hub.docker.com/_/openjdk
As suggested we can use `eclipse-temurin` which is popular and recommended (https://whichjdk.com/).